### PR TITLE
Call initialize function on implementation contracts

### DIFF
--- a/packages/hardhat/scripts/tasks/deployVault.js
+++ b/packages/hardhat/scripts/tasks/deployVault.js
@@ -4,6 +4,18 @@ const deployVault = async (name, args) => {
   const contractName = network === "fantom" ? "FujiVaultFTM" : "FujiVault";
 
   const deployed = await redeployIf(name, contractName, () => false, deployProxy, args);
+
+  // Call initialize function of the implementation contract if it's not already called.
+  // This is a precaution measure to make sure a malicious actor won't take control
+  // of the implementation contract.
+  const implAddr = await upgrades.erc1967.getImplementationAddress(deployed);
+  const implContract = await ethers.getContractAt(contractName, implAddr);
+  const implOwner = await implContract.owner();
+  if (implOwner === "0x0000000000000000000000000000000000000000") {
+    await implContract.initialize(...args);
+    console.log(`Implementation contract ${contractName}: initialized`);
+  }
+
   return deployed;
 };
 

--- a/packages/hardhat/scripts/utils.js
+++ b/packages/hardhat/scripts/utils.js
@@ -108,22 +108,9 @@ const deployProxy = async (name, contractName, args = [], overrides = {}) => {
     contractArtifacts.interface.functions[initializeFunction].inputs,
     contractArgs
   );
-
   fs.writeFileSync(`artifacts/${name}.address`, deployed.address);
 
   await updateDeployments(name, contractName, deployed.address);
-
-  // Call initialize function of the implementation contract
-  // if it's not already called.
-  // This is a precaution measure to make sure a malicious actor won't take control
-  // of the implementation contract.
-  const implAddr = await upgrades.erc1967.getImplementationAddress(deployed.address);
-  const implContract = await ethers.getContractAt(contractName, implAddr);
-  const implOwner = await implContract.owner();
-  if (implOwner === "0x0000000000000000000000000000000000000000") {
-    await implContract.initialize(...contractArgs);
-    console.log(`Implementation contract ${contractName}: initialized`);
-  }
 
   if (!encoded || encoded.length <= 2) return deployed;
   fs.writeFileSync(`artifacts/${name}.args`, encoded.slice(2));


### PR DESCRIPTION
[1] Anyone can destroy the FujiVault logic contract if its initialize function was not called during deployment