### PR TITLE
Add collateral liquidation price to position ratio changes modal

### DIFF
--- a/packages/react-app/src/index.css
+++ b/packages/react-app/src/index.css
@@ -549,13 +549,17 @@ input[type='number'] {
 }
 
 .MuiDialog-paper {
-  width: 25rem;
+  width: 50rem;
   height: auto;
   padding: 2rem;
   background-color: var(--bg);
   box-shadow: 0rem 0.25rem 0.25rem rgba(0, 0, 0, 0.25);
   border: 0.1rem solid var(--text32);
   border-radius: 1rem;
+}
+
+.MuiDialog-paperWidthSm {
+  max-width: 550px;
 }
 
 .MuiDialog-paper .close {

--- a/packages/react-app/src/screens/Dashboard/DeltaPositionRatios/index.jsx
+++ b/packages/react-app/src/screens/Dashboard/DeltaPositionRatios/index.jsx
@@ -13,6 +13,7 @@ function DeltaPositionRatios({ vault, currentCollateral, currentDebt, newCollate
   const [healthFactor, setHealthFactor] = useState([]);
   const [borrowLimit, setLimit] = useState([]);
   const [ltv, setLtv] = useState([]);
+  const [liqPrice, setLiqPrice] = useState([]);
 
   useEffect(() => {
     async function fetchValues() {
@@ -27,6 +28,7 @@ function DeltaPositionRatios({ vault, currentCollateral, currentDebt, newCollate
       const {
         healthFactor: oldHf,
         ltv: oldLtv,
+        liqPrice: oldLiqPrice,
         borrowLimit: oldLimit,
       } = PositionRatios(position, collateralAssetPrice, borrowAssetPrice);
 
@@ -38,12 +40,14 @@ function DeltaPositionRatios({ vault, currentCollateral, currentDebt, newCollate
       const {
         healthFactor: newHf,
         ltv: newLtv,
+        liqPrice: newLiqPrice,
         borrowLimit: newLimit,
       } = PositionRatios(position, collateralAssetPrice, borrowAssetPrice);
 
       setHealthFactor([oldHf, newHf]);
       setLtv([oldLtv * 100, newLtv * 100]);
       setLimit([oldLimit * 100, newLimit * 100]);
+      setLiqPrice([oldLiqPrice, newLiqPrice]);
     }
 
     fetchValues();
@@ -77,6 +81,15 @@ function DeltaPositionRatios({ vault, currentCollateral, currentDebt, newCollate
         <ListItemSecondaryAction>
           <Typography component="span" variant="h3">
             {formatValue(ltv[0], 1) + ' % -> ' + formatValue(ltv[1], 1) + ' %'}
+          </Typography>
+        </ListItemSecondaryAction>
+      </ListItem>
+      <Divider component="li" style={{ backgroundColor: 'rgba(255,255,255,0.12)' }} />
+      <ListItem alignItems="flex-start">
+        <ListItemText primary={`${vault.collateralAsset.name} liquidation price`} />
+        <ListItemSecondaryAction>
+          <Typography component="span" variant="h3">
+            {'$ ' + formatValue(liqPrice[0], 2) + ' -> $ ' + formatValue(liqPrice[1], 2)}
           </Typography>
         </ListItemSecondaryAction>
       </ListItem>


### PR DESCRIPTION
Closes issue #137 

This PR adds the collateral liquidation price to the position ratio changes modal.

In order to support large numbers I had to modify the styling of the modal itself (I increased the max modal width from 450px to 550px) so we will have to check if it doesn't cause any issues.

![liq ratio](https://user-images.githubusercontent.com/95942363/146679250-3e218654-071f-42b7-803a-baac7f213f43.PNG)

